### PR TITLE
fix: 28기 시작, 마감 시간 수정

### DIFF
--- a/src/constants/recruit/recruit.ko.ts
+++ b/src/constants/recruit/recruit.ko.ts
@@ -8,8 +8,8 @@ const RECRUIT = {
   CONTENT:
     "에코노베이션에서 함께할 여러분을 모집합니다.\n에코노베이션은 지식의 선순환이 자연스럽게 이루어지는 환경을 만드는 것을 목표하고 있습니다.\n개발에 열정이 있다면 에코노베이션에 들어와 지식의 선순환을 일으켜주세요.",
   IS_ON: true /** FIXME: This property was deprecated. */,
-  START_DATE: Date.UTC(2024, 8, 2, 9, 0, 0),
-  END_DATE: Date.UTC(2024, 8, 15, 23, 59, 59),
+  START_DATE: Date.UTC(2024, 8, 2, 0, 0, 0),
+  END_DATE: Date.UTC(2024, 8, 15, 14, 59, 59),
   GENERTAION: 28,
   SCHEDULE: [
     { TEXT: "서류 접수 시작", DATE: "9/2" },


### PR DESCRIPTION
## 문제 상황
시간이 9시간이 더해진 상태로 되어있었습니다! 

![image](https://github.com/user-attachments/assets/f03e2389-5184-4f66-918a-7c9e311ace11)

## 해결

기존에 9시간이 더해진 상태로 되어있던 부분(start_date, end_date)을 수정하였습니다. 

![image](https://github.com/user-attachments/assets/88075597-5223-4352-8b6c-b145ea3b1425)


## 리뷰어에게 
추가적인 문제가 있는지 확인 부탁드립니다! 