### PR TITLE
feat: 32기 신입 모집 관련 업데이트

### DIFF
--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -1,4 +1,4 @@
-import { RECRUIT } from "@/src/constants/recruit/recruit.ko";
+import { formatOrdinal, RECRUIT } from "@/src/constants/recruit/recruit.ko";
 import { LinkTo } from "@/src/components/common/LinkTo";
 import { MAIN_NAV } from "@/src/constants/main.ko";
 import { HambergerMenu } from "./Hamberger";
@@ -24,7 +24,7 @@ const NavbarDesktop = () => {
             key={data.LINK}
             link={data.LINK}
           >
-            {`${RECRUIT.GENERATION}ST`} {data.NAME}
+            {formatOrdinal(RECRUIT.GENERATION)} {data.NAME}
           </LinkTo>
         ))}
       </div>

--- a/src/constants/recruit/recruit.ko.ts
+++ b/src/constants/recruit/recruit.ko.ts
@@ -8,15 +8,15 @@ const RECRUIT = {
   CONTENT:
     "에코노베이션에서 함께할 여러분을 모집합니다.\n에코노베이션은 지식의 선순환이 자연스럽게 이루어지는 환경을 만드는 것을 목표하고 있습니다.\n개발에 열정이 있다면 에코노베이션에 들어와 지식의 선순환을 일으켜주세요.",
   IS_ON: true /** FIXME: This property was deprecated. */,
-  START_DATE: Date.UTC(2026, 1, 28, 15, 0, 0),
-  END_DATE: Date.UTC(2026, 2, 10, 14, 59, 59),
-  ANNOUNCE_DATE: Date.UTC(2025, 8, 12, 0, 0, 0),
-  GENERATION: 31,
+  START_DATE: Date.UTC(2026, 7, 27, 15, 0, 0),
+  END_DATE: Date.UTC(2026, 8, 9, 14, 59, 59),
+  ANNOUNCE_DATE: Date.UTC(2026, 8, 21, 0, 0, 0),
+  GENERATION: 32,
   SCHEDULE: [
-    { TEXT: "서류 접수 시작", DATE: "3/1" },
-    { TEXT: "서류 접수 마감", DATE: "3/10" },
-    { TEXT: "면접 진행", DATE: "3/17 ~ 3/19" },
-    { TEXT: "최종 합격 안내", DATE: "3/23" },
+    { TEXT: "서류 접수 시작", DATE: "8/28" },
+    { TEXT: "서류 접수 마감", DATE: "9/9" },
+    { TEXT: "면접 진행", DATE: "9/15 ~ 9/18" },
+    { TEXT: "최종 합격 안내", DATE: "9/21" },
   ],
   WAITING: {
     TITLE: "comming soon",

--- a/src/constants/recruit/recruit.ko.ts
+++ b/src/constants/recruit/recruit.ko.ts
@@ -3,6 +3,23 @@ import { URLS } from "../url.ko";
 
 export type RecruitStatus = "READY" | "OPEN" | "CLOSED";
 
+const formatOrdinal = (value: number) => {
+  const remainder = value % 100;
+
+  if (remainder >= 11 && remainder <= 13) return `${value}th`;
+
+  switch (value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+};
+
 const RECRUIT = {
   TITLE: "recruit",
   CONTENT:
@@ -110,7 +127,9 @@ const RECRUIT = {
 const RECRUIT_FLOAT = {
   ECONO_IS_RECRUITING: "econovation은 지금 신입 모집 중!",
   ECONO_READY_FOR_RECRUIT: "econovation 신입 모집 시작까지",
-  ECONO_GENERTAION_RECRUIT_EN: `econovation ${RECRUIT.GENERATION}th recruit`,
+  ECONO_GENERTAION_RECRUIT_EN: `econovation ${formatOrdinal(
+    RECRUIT.GENERATION
+  )} recruit`,
   ECONO_GENERTAION_RECRUIT_KR: `에코노베이션 ${RECRUIT.GENERATION}기 신입 모집`,
   DAY: "day",
   HOUR: "hour",
@@ -118,4 +137,4 @@ const RECRUIT_FLOAT = {
   SECOND: "second",
 };
 
-export { RECRUIT, RECRUIT_FLOAT };
+export { RECRUIT, RECRUIT_FLOAT, formatOrdinal };

--- a/src/hooks/useRecruitStatus.ts
+++ b/src/hooks/useRecruitStatus.ts
@@ -23,7 +23,7 @@ const useRecruitStatus = () => {
   useEffect(() => {
     const intervalId = setInterval(() => {
       setRecruitStatus(getRecruitStatus());
-    }, 0);
+    }, 1000);
     return () => {
       clearInterval(intervalId);
     };

--- a/src/hooks/useTimeDiffer.tsx
+++ b/src/hooks/useTimeDiffer.tsx
@@ -3,13 +3,25 @@
 import { useEffect, useState } from "react";
 import { getTimeDiff } from "../functions/util";
 
+const INITIAL_TIME = {
+  days: 0,
+  hours: 0,
+  minutes: 0,
+  seconds: 0,
+};
+
 export const useTimeDiffer = (date: Date) => {
-  const [time, setTime] = useState(getTimeDiff(date));
+  const [time, setTime] = useState(INITIAL_TIME);
+  const targetTime = date.getTime();
 
   useEffect(() => {
-    const timer = setInterval(() => setTime(getTimeDiff(date)), 1000);
+    const updateTime = () => setTime(getTimeDiff(new Date(targetTime)));
+
+    updateTime();
+    const timer = setInterval(updateTime, 1000);
+
     return () => clearInterval(timer);
-  }, [date]);
+  }, [targetTime]);
 
   return { ...time };
 };


### PR DESCRIPTION
## 관련 이슈
- close #160 

## 작업 내용

  - 32기 신입 모집 정보 반영
      - 모집 시작: 2026년 8월 28일
      - 모집 마감: 2026년 9월 9일
      - 면접 진행: 2026년 9월 15일 ~ 18일
      - 최종 합격 발표: 2026년 9월 21일

  - 영문 기수 표기를 32nd로 수정
  - 카운트다운 서버·클라이언트 렌더링 불일치 문제 수정
  - 모집 상태 확인 주기를 1초로 조정

  ## 테스트

  - 메인 및 모집 페이지 정상 응답 확인
  - 카운트다운 동작 확인
  - ESLint 통과